### PR TITLE
chore: update github actions version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Push gigs into repository
-        uses: github-actions-x/commit@v2.8
+        uses: github-actions-x/commit@v2.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'main'


### PR DESCRIPTION
Updating the GitHub Actions version for `github-actions-x-/commit` which fixes the git permission issue due to changes rolled out in the GitHub platform.