### PR TITLE
feat: add missing talks from 2022-2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -8,7 +8,7 @@
 
  - [Year of 2025](#2025) - total events 5
  - [Year of 2024](#2024) - total events 3
- - [Year of 2023](#2023) - total events 6
+ - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
@@ -55,7 +55,7 @@
 # 2023
 
 
-![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-7-red?style=flat-square)    
 
 
 
@@ -67,6 +67,7 @@
 | 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
 | 2023-6-2 | JSNation 2023 | [APIs are Evolving. Again](pages/2023/jsnation-apis-evolving.md) |  | [Recording](https://www.youtube.com/watch?v=P3yu0bQtLLI) | [🇳🇱](## "Netherlands") | English |
 | 2023-6-1 | JSNation 2023 | [I Would Never Use an ORM](pages/2023/jsnation-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=bEy2QMKrcWg) | [🇳🇱](## "Netherlands") | English |
+| 2023-5-31 | CityJS Athens 2023 | [Do not thrash the Node.js Event Loop](pages/2023/cityjs-athens.md) |  |  | [🇬🇷](## "Greece") | English |
 | 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
 
 
@@ -294,4 +295,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:55:45.847Z</i>
+<i>Updated on 2026-02-14T10:40:36.876Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -7,7 +7,7 @@
 
 
  - [Year of 2025](#2025) - total events 5
- - [Year of 2024](#2024) - total events 3
+ - [Year of 2024](#2024) - total events 4
  - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
@@ -40,7 +40,7 @@
 # 2024
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
 
 
 
@@ -50,6 +50,7 @@
 | 2024-6-24 | Frontend Nation 2024 | [Which Node.js HTTP client in 2024?](pages/2024/frontend-nation-http-client.md) |  | [Recording](https://www.youtube.com/watch?v=fePTmnQHQZ4) |  | English |
 | 2024-5-1 | JSDay 2024 | [The State of Node.js 2024](pages/2024/jsday-2024.md) |  |  | [🇮🇹](## "Italy") | English |
 | 2024-4-17 | Node Congress 2024 | [Deep Dive into Undici](pages/2024/node-congress-deep-dive-undici.md) |  | [Recording](https://www.youtube.com/watch?v=cIyiDDts0lo) | [🇩🇪](## "Germany") | English |
+| 2024-4-5 | CityJS London 2024 | [The Alleged 'End' of Node.js is Much Ado About Nothing](pages/2024/cityjs-london.md) |  |  | [🇬🇧](## "United Kingdom") | English |
 
 
 # 2023
@@ -295,4 +296,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T10:40:36.876Z</i>
+<i>Updated on 2026-02-14T10:41:23.888Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -8,8 +8,8 @@
 
  - [Year of 2025](#2025) - total events 3
  - [Year of 2024](#2024) - total events 3
- - [Year of 2023](#2023) - total events 4
- - [Year of 2022](#2022) - total events 7
+ - [Year of 2023](#2023) - total events 6
+ - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
  - [Year of 2019](#2019) - total events 10
@@ -53,7 +53,7 @@
 # 2023
 
 
-![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
 
 
 
@@ -63,19 +63,22 @@
 | 2023-12-2 | Node.js fwdays'23 | [NODE_ENV=production is a lie](pages/2023/fwdays-nodejs-node-env.md) |  | [Recording](https://www.youtube.com/watch?v=irRsEfCTTtg) |  | English |
 | 2023-10-17 | React + TypeScript fwdays'23 | [Generating types without climbing a tree](pages/2023/react-typescript-fwdays-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3dSNut_iiVY) |  | English |
 | 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
+| 2023-6-2 | JSNation 2023 | [APIs are Evolving. Again](pages/2023/jsnation-apis-evolving.md) |  | [Recording](https://www.youtube.com/watch?v=P3yu0bQtLLI) | [🇳🇱](## "Netherlands") | English |
+| 2023-6-1 | JSNation 2023 | [I Would Never Use an ORM](pages/2023/jsnation-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=bEy2QMKrcWg) | [🇳🇱](## "Netherlands") | English |
 | 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
 
 
 # 2022
 
 
-![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+![Total Events](https://img.shields.io/badge/total-8-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2022-10-1 | NodeConf EU 2022 | [I would never use an ORM](pages/2022/nodeconf-eu-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=atABji4xqiI) | [🇮🇪](## "Ireland") | English |
 | 2022-6-7 | OpenJS World 2022 | [Keynote - Everybody is Responsible for Performance](pages/2022/openjs-world-keynote.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [A Fastify tale of Shapes](pages/2022/openjs-world-fastify.md) |  | [Recording](https://www.youtube.com/watch?v=g-6Ig8k6Nzc&list=PLyspMSh4XhLMSpb4yqi0aPxSioNaP1Wkn) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [Everybody is Responsible for Performance](pages/2022/openjs-world-performance.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
@@ -289,4 +292,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:32:40.646Z</i>
+<i>Updated on 2026-02-14T09:40:59.290Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 3
+ - [Year of 2025](#2025) - total events 4
  - [Year of 2024](#2024) - total events 3
  - [Year of 2023](#2023) - total events 6
  - [Year of 2022](#2022) - total events 8
@@ -23,7 +23,7 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
 
 
 
@@ -31,6 +31,7 @@
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
 | 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
 
@@ -292,4 +293,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:40:59.290Z</i>
+<i>Updated on 2026-02-14T09:42:41.643Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-99-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-59-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,10 @@
 # Table of Contents
 
 
- - [Year of 2022](#2022) - total events 6
+ - [Year of 2025](#2025) - total events 3
+ - [Year of 2024](#2024) - total events 3
+ - [Year of 2023](#2023) - total events 4
+ - [Year of 2022](#2022) - total events 7
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
  - [Year of 2019](#2019) - total events 10
@@ -17,16 +20,63 @@
  - [Year of 2014](#2014) - total events 5
  - [Year of 2013](#2013) - total events 2
 
-# 2022
+# 2025
 
 
-![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
+| 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
+
+
+# 2024
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2024-6-24 | Frontend Nation 2024 | [Which Node.js HTTP client in 2024?](pages/2024/frontend-nation-http-client.md) |  | [Recording](https://www.youtube.com/watch?v=fePTmnQHQZ4) |  | English |
+| 2024-5-1 | JSDay 2024 | [The State of Node.js 2024](pages/2024/jsday-2024.md) |  |  | [🇮🇹](## "Italy") | English |
+| 2024-4-17 | Node Congress 2024 | [Deep Dive into Undici](pages/2024/node-congress-deep-dive-undici.md) |  | [Recording](https://www.youtube.com/watch?v=cIyiDDts0lo) | [🇩🇪](## "Germany") | English |
+
+
+# 2023
+
+
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2023-12-2 | Node.js fwdays'23 | [NODE_ENV=production is a lie](pages/2023/fwdays-nodejs-node-env.md) |  | [Recording](https://www.youtube.com/watch?v=irRsEfCTTtg) |  | English |
+| 2023-10-17 | React + TypeScript fwdays'23 | [Generating types without climbing a tree](pages/2023/react-typescript-fwdays-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3dSNut_iiVY) |  | English |
+| 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
+| 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
+
+
+# 2022
+
+
+![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2022-6-7 | OpenJS World 2022 | [Keynote - Everybody is Responsible for Performance](pages/2022/openjs-world-keynote.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [A Fastify tale of Shapes](pages/2022/openjs-world-fastify.md) |  | [Recording](https://www.youtube.com/watch?v=g-6Ig8k6Nzc&list=PLyspMSh4XhLMSpb4yqi0aPxSioNaP1Wkn) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [Everybody is Responsible for Performance](pages/2022/openjs-world-performance.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
 | 2022-2-25 | Design Talk | [Always put the client first](pages/2022/design-talk.md) |  | [Recording](https://shows.acast.com/design-talk/episodes/always-put-the-client-first) |  | English |
@@ -239,4 +289,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2022-07-01T16:04:02.983Z</i>
+<i>Updated on 2026-02-14T09:32:40.646Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 4
+ - [Year of 2025](#2025) - total events 5
  - [Year of 2024](#2024) - total events 3
  - [Year of 2023](#2023) - total events 6
  - [Year of 2022](#2022) - total events 8
@@ -23,13 +23,14 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-5-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square)    
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2025-11-1 | JSConf 2025 | [Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work](pages/2025/jsconf-us.md) |  | [Recording](https://www.youtube.com/watch?v=2VkUF8jzouQ) | [🇺🇸](## "United States") | English |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
 | 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
@@ -293,4 +294,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:42:41.643Z</i>
+<i>Updated on 2026-02-14T09:55:45.847Z</i>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-118-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-78-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 5
+ - [Year of 2025](#2025) - total events 6
  - [Year of 2024](#2024) - total events 4
  - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
@@ -23,7 +23,7 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-5-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
 
 
 
@@ -32,6 +32,7 @@
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
 | 2025-11-1 | JSConf 2025 | [Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work](pages/2025/jsconf-us.md) |  | [Recording](https://www.youtube.com/watch?v=2VkUF8jzouQ) | [🇺🇸](## "United States") | English |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-9-3 | Code Europe 2025 | [Node.js: More Threads Than You Think](pages/2025/code-europe.md) |  | [Recording](https://www.youtube.com/watch?v=r5PIqYyRiAg) | [🇵🇱](## "Poland") | English |
 | 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
 | 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
@@ -296,4 +297,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T10:41:23.888Z</i>
+<i>Updated on 2026-02-14T10:42:30.039Z</i>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -24,8 +24,8 @@
 <ul>
 <li><a href="#2025">Year of 2025</a> - total events 3</li>
 <li><a href="#2024">Year of 2024</a> - total events 3</li>
-<li><a href="#2023">Year of 2023</a> - total events 4</li>
-<li><a href="#2022">Year of 2022</a> - total events 7</li>
+<li><a href="#2023">Year of 2023</a> - total events 6</li>
+<li><a href="#2022">Year of 2022</a> - total events 8</li>
 <li><a href="#2021">Year of 2021</a> - total events 29</li>
 <li><a href="#2020">Year of 2020</a> - total events 23</li>
 <li><a href="#2019">Year of 2019</a> - total events 10</li>
@@ -125,7 +125,7 @@
 </tbody>
 </table>
 <h1 id="2023" tabindex="-1">2023</h1>
-<p><img src="https://img.shields.io/badge/total-4-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-6-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-6-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -167,6 +167,24 @@
 <td>English</td>
 </tr>
 <tr>
+<td>2023-6-2</td>
+<td>JSNation 2023</td>
+<td><a href="pages/2023/jsnation-apis-evolving.md">APIs are Evolving. Again</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=P3yu0bQtLLI">Recording</a></td>
+<td><a href="##" title="Netherlands">🇳🇱</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2023-6-1</td>
+<td>JSNation 2023</td>
+<td><a href="pages/2023/jsnation-never-use-orm.md">I Would Never Use an ORM</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=bEy2QMKrcWg">Recording</a></td>
+<td><a href="##" title="Netherlands">🇳🇱</a></td>
+<td>English</td>
+</tr>
+<tr>
 <td>2023-4-14</td>
 <td>Node Congress 2023</td>
 <td><a href="pages/2023/node-congress-modular-monolith.md">Building a modular monolith with Fastify</a></td>
@@ -178,7 +196,7 @@
 </tbody>
 </table>
 <h1 id="2022" tabindex="-1">2022</h1>
-<p><img src="https://img.shields.io/badge/total-7-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-1-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-2-yellow?style=flat-square" alt="Total Podcasts"></p>
+<p><img src="https://img.shields.io/badge/total-8-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-1-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-5-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-2-yellow?style=flat-square" alt="Total Podcasts"></p>
 <table>
 <thead>
 <tr>
@@ -192,6 +210,15 @@
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>2022-10-1</td>
+<td>NodeConf EU 2022</td>
+<td><a href="pages/2022/nodeconf-eu-never-use-orm.md">I would never use an ORM</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=atABji4xqiI">Recording</a></td>
+<td><a href="##" title="Ireland">🇮🇪</a></td>
+<td>English</td>
+</tr>
 <tr>
 <td>2022-6-7</td>
 <td>OpenJS World 2022</td>
@@ -1248,7 +1275,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T09:32:40.646Z</i></p>
+<p><i>Updated on 2026-02-14T09:40:59.290Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -24,7 +24,7 @@
 <ul>
 <li><a href="#2025">Year of 2025</a> - total events 5</li>
 <li><a href="#2024">Year of 2024</a> - total events 3</li>
-<li><a href="#2023">Year of 2023</a> - total events 6</li>
+<li><a href="#2023">Year of 2023</a> - total events 7</li>
 <li><a href="#2022">Year of 2022</a> - total events 8</li>
 <li><a href="#2021">Year of 2021</a> - total events 29</li>
 <li><a href="#2020">Year of 2020</a> - total events 23</li>
@@ -143,7 +143,7 @@
 </tbody>
 </table>
 <h1 id="2023" tabindex="-1">2023</h1>
-<p><img src="https://img.shields.io/badge/total-6-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-6-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-7-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-7-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -200,6 +200,15 @@
 <td></td>
 <td><a href="https://www.youtube.com/watch?v=bEy2QMKrcWg">Recording</a></td>
 <td><a href="##" title="Netherlands">🇳🇱</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2023-5-31</td>
+<td>CityJS Athens 2023</td>
+<td><a href="pages/2023/cityjs-athens.md">Do not thrash the Node.js Event Loop</a></td>
+<td></td>
+<td></td>
+<td><a href="##" title="Greece">🇬🇷</a></td>
 <td>English</td>
 </tr>
 <tr>
@@ -1293,7 +1302,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T09:55:45.847Z</i></p>
+<p><i>Updated on 2026-02-14T10:40:36.876Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,14 +16,14 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
 <h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
 <ul>
 <li><a href="#2025">Year of 2025</a> - total events 5</li>
-<li><a href="#2024">Year of 2024</a> - total events 3</li>
+<li><a href="#2024">Year of 2024</a> - total events 4</li>
 <li><a href="#2023">Year of 2023</a> - total events 7</li>
 <li><a href="#2022">Year of 2022</a> - total events 8</li>
 <li><a href="#2021">Year of 2021</a> - total events 29</li>
@@ -99,7 +99,7 @@
 </tbody>
 </table>
 <h1 id="2024" tabindex="-1">2024</h1>
-<p><img src="https://img.shields.io/badge/total-3-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-3-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-4-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -138,6 +138,15 @@
 <td></td>
 <td><a href="https://www.youtube.com/watch?v=cIyiDDts0lo">Recording</a></td>
 <td><a href="##" title="Germany">🇩🇪</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2024-4-5</td>
+<td>CityJS London 2024</td>
+<td><a href="pages/2024/cityjs-london.md">The Alleged 'End' of Node.js is Much Ado About Nothing</a></td>
+<td></td>
+<td></td>
+<td><a href="##" title="United Kingdom">🇬🇧</a></td>
 <td>English</td>
 </tr>
 </tbody>
@@ -1302,7 +1311,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T10:40:36.876Z</i></p>
+<p><i>Updated on 2026-02-14T10:41:23.888Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,13 +16,13 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
 <h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
 <ul>
-<li><a href="#2025">Year of 2025</a> - total events 3</li>
+<li><a href="#2025">Year of 2025</a> - total events 4</li>
 <li><a href="#2024">Year of 2024</a> - total events 3</li>
 <li><a href="#2023">Year of 2023</a> - total events 6</li>
 <li><a href="#2022">Year of 2022</a> - total events 8</li>
@@ -37,7 +37,7 @@
 <li><a href="#2013">Year of 2013</a> - total events 2</li>
 </ul>
 <h1 id="2025" tabindex="-1">2025</h1>
-<p><img src="https://img.shields.io/badge/total-3-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-3-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-4-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -58,6 +58,15 @@
 <td></td>
 <td><a href="https://www.youtube.com/watch?v=h3qKJabs7d4">Recording</a></td>
 <td><a href="##" title="Italy">🇮🇹</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2025-6-12</td>
+<td>JSNation 2025</td>
+<td><a href="pages/2025/jsnation-amsterdam.md">The State of Node.js 2025</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=IgSwJaheiGk">Recording</a></td>
+<td><a href="##" title="Netherlands">🇳🇱</a></td>
 <td>English</td>
 </tr>
 <tr>
@@ -1275,7 +1284,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T09:40:59.290Z</i></p>
+<p><i>Updated on 2026-02-14T09:42:41.643Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,13 +16,13 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-118-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-78-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
 <h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
 <ul>
-<li><a href="#2025">Year of 2025</a> - total events 5</li>
+<li><a href="#2025">Year of 2025</a> - total events 6</li>
 <li><a href="#2024">Year of 2024</a> - total events 4</li>
 <li><a href="#2023">Year of 2023</a> - total events 7</li>
 <li><a href="#2022">Year of 2022</a> - total events 8</li>
@@ -37,7 +37,7 @@
 <li><a href="#2013">Year of 2013</a> - total events 2</li>
 </ul>
 <h1 id="2025" tabindex="-1">2025</h1>
-<p><img src="https://img.shields.io/badge/total-5-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-5-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-6-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-6-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -67,6 +67,15 @@
 <td></td>
 <td><a href="https://www.youtube.com/watch?v=h3qKJabs7d4">Recording</a></td>
 <td><a href="##" title="Italy">🇮🇹</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2025-9-3</td>
+<td>Code Europe 2025</td>
+<td><a href="pages/2025/code-europe.md">Node.js: More Threads Than You Think</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=r5PIqYyRiAg">Recording</a></td>
+<td><a href="##" title="Poland">🇵🇱</a></td>
 <td>English</td>
 </tr>
 <tr>
@@ -1311,7 +1320,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T10:41:23.888Z</i></p>
+<p><i>Updated on 2026-02-14T10:42:30.039Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,13 +16,16 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-99-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-59-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
 <h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
 <ul>
-<li><a href="#2022">Year of 2022</a> - total events 6</li>
+<li><a href="#2025">Year of 2025</a> - total events 3</li>
+<li><a href="#2024">Year of 2024</a> - total events 3</li>
+<li><a href="#2023">Year of 2023</a> - total events 4</li>
+<li><a href="#2022">Year of 2022</a> - total events 7</li>
 <li><a href="#2021">Year of 2021</a> - total events 29</li>
 <li><a href="#2020">Year of 2020</a> - total events 23</li>
 <li><a href="#2019">Year of 2019</a> - total events 10</li>
@@ -33,8 +36,8 @@
 <li><a href="#2014">Year of 2014</a> - total events 5</li>
 <li><a href="#2013">Year of 2013</a> - total events 2</li>
 </ul>
-<h1 id="2022" tabindex="-1">2022</h1>
-<p><img src="https://img.shields.io/badge/total-6-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-1-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-3-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-2-yellow?style=flat-square" alt="Total Podcasts"></p>
+<h1 id="2025" tabindex="-1">2025</h1>
+<p><img src="https://img.shields.io/badge/total-3-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-3-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -48,6 +51,156 @@
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>2025-10-14</td>
+<td>JSDay 2025</td>
+<td><a href="pages/2025/jsday-state-of-nodejs-2025.md">The State of Node.js 2025</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=h3qKJabs7d4">Recording</a></td>
+<td><a href="##" title="Italy">🇮🇹</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2025-4-3</td>
+<td>dotJS 2025</td>
+<td><a href="pages/2025/dotjs-nodejs-memory.md">Node.js will use all the memory available, and that's OK!</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=_OnTUIYxGRs">Recording</a></td>
+<td><a href="##" title="France">🇫🇷</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2025-3-15</td>
+<td>Conference 2025</td>
+<td><a href="pages/2025/why-nodejs-needs-application-server.md">Why Node.js Needs an Application Server</a></td>
+<td></td>
+<td></td>
+<td></td>
+<td>English</td>
+</tr>
+</tbody>
+</table>
+<h1 id="2024" tabindex="-1">2024</h1>
+<p><img src="https://img.shields.io/badge/total-3-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-3-red?style=flat-square" alt="Total Conferences"></p>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Event</th>
+<th>Title</th>
+<th>Slides</th>
+<th>Recording</th>
+<th>Location</th>
+<th>Language</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2024-6-24</td>
+<td>Frontend Nation 2024</td>
+<td><a href="pages/2024/frontend-nation-http-client.md">Which Node.js HTTP client in 2024?</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=fePTmnQHQZ4">Recording</a></td>
+<td></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2024-5-1</td>
+<td>JSDay 2024</td>
+<td><a href="pages/2024/jsday-2024.md">The State of Node.js 2024</a></td>
+<td></td>
+<td></td>
+<td><a href="##" title="Italy">🇮🇹</a></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2024-4-17</td>
+<td>Node Congress 2024</td>
+<td><a href="pages/2024/node-congress-deep-dive-undici.md">Deep Dive into Undici</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=cIyiDDts0lo">Recording</a></td>
+<td><a href="##" title="Germany">🇩🇪</a></td>
+<td>English</td>
+</tr>
+</tbody>
+</table>
+<h1 id="2023" tabindex="-1">2023</h1>
+<p><img src="https://img.shields.io/badge/total-4-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"></p>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Event</th>
+<th>Title</th>
+<th>Slides</th>
+<th>Recording</th>
+<th>Location</th>
+<th>Language</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2023-12-2</td>
+<td>Node.js fwdays'23</td>
+<td><a href="pages/2023/fwdays-nodejs-node-env.md">NODE_ENV=production is a lie</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=irRsEfCTTtg">Recording</a></td>
+<td></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2023-10-17</td>
+<td>React + TypeScript fwdays'23</td>
+<td><a href="pages/2023/react-typescript-fwdays-generating-types.md">Generating types without climbing a tree</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=3dSNut_iiVY">Recording</a></td>
+<td></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2023-9-21</td>
+<td>TypeScript Congress 2023</td>
+<td><a href="pages/2023/typescript-congress-generating-types.md">Generating types without climbing a tree</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=3BROtlRhDYE">Recording</a></td>
+<td></td>
+<td>English</td>
+</tr>
+<tr>
+<td>2023-4-14</td>
+<td>Node Congress 2023</td>
+<td><a href="pages/2023/node-congress-modular-monolith.md">Building a modular monolith with Fastify</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=e1jkA-ee_aY">Recording</a></td>
+<td><a href="##" title="Germany">🇩🇪</a></td>
+<td>English</td>
+</tr>
+</tbody>
+</table>
+<h1 id="2022" tabindex="-1">2022</h1>
+<p><img src="https://img.shields.io/badge/total-7-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-1-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-2-yellow?style=flat-square" alt="Total Podcasts"></p>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Event</th>
+<th>Title</th>
+<th>Slides</th>
+<th>Recording</th>
+<th>Location</th>
+<th>Language</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2022-6-7</td>
+<td>OpenJS World 2022</td>
+<td><a href="pages/2022/openjs-world-keynote.md">Keynote - Everybody is Responsible for Performance</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=A99zkgoFd18">Recording</a></td>
+<td><a href="##" title="United States">🇺🇸</a></td>
+<td>English</td>
+</tr>
 <tr>
 <td>2022-6-6</td>
 <td>OpenJS World 2022</td>
@@ -1095,7 +1248,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2022-07-01T16:04:02.983Z</i></p>
+<p><i>Updated on 2026-02-14T09:32:40.646Z</i></p>
 
         
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,13 +16,13 @@
 <body>
     <main>
         
-        <div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+        <div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
 <h1 id="table-of-contents" tabindex="-1">Table of Contents</h1>
 <ul>
-<li><a href="#2025">Year of 2025</a> - total events 4</li>
+<li><a href="#2025">Year of 2025</a> - total events 5</li>
 <li><a href="#2024">Year of 2024</a> - total events 3</li>
 <li><a href="#2023">Year of 2023</a> - total events 6</li>
 <li><a href="#2022">Year of 2022</a> - total events 8</li>
@@ -37,7 +37,7 @@
 <li><a href="#2013">Year of 2013</a> - total events 2</li>
 </ul>
 <h1 id="2025" tabindex="-1">2025</h1>
-<p><img src="https://img.shields.io/badge/total-4-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-4-red?style=flat-square" alt="Total Conferences"></p>
+<p><img src="https://img.shields.io/badge/total-5-blue?style=flat-square" alt="Total Events">  <img src="https://img.shields.io/badge/conferences-5-red?style=flat-square" alt="Total Conferences"></p>
 <table>
 <thead>
 <tr>
@@ -51,6 +51,15 @@
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>2025-11-1</td>
+<td>JSConf 2025</td>
+<td><a href="pages/2025/jsconf-us.md">Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work</a></td>
+<td></td>
+<td><a href="https://www.youtube.com/watch?v=2VkUF8jzouQ">Recording</a></td>
+<td><a href="##" title="United States">🇺🇸</a></td>
+<td>English</td>
+</tr>
 <tr>
 <td>2025-10-14</td>
 <td>JSDay 2025</td>
@@ -1284,7 +1293,7 @@
 </tbody>
 </table>
 <p><em>A few talks have been omitted or have gone into oblivion.</em></p>
-<p><i>Updated on 2026-02-14T09:42:41.643Z</i></p>
+<p><i>Updated on 2026-02-14T09:55:45.847Z</i></p>
 
         
     </main>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -8,7 +8,7 @@
 
  - [Year of 2025](#2025) - total events 5
  - [Year of 2024](#2024) - total events 3
- - [Year of 2023](#2023) - total events 6
+ - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
@@ -55,7 +55,7 @@
 # 2023
 
 
-![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-7-red?style=flat-square)    
 
 
 
@@ -67,6 +67,7 @@
 | 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
 | 2023-6-2 | JSNation 2023 | [APIs are Evolving. Again](pages/2023/jsnation-apis-evolving.md) |  | [Recording](https://www.youtube.com/watch?v=P3yu0bQtLLI) | [🇳🇱](## "Netherlands") | English |
 | 2023-6-1 | JSNation 2023 | [I Would Never Use an ORM](pages/2023/jsnation-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=bEy2QMKrcWg) | [🇳🇱](## "Netherlands") | English |
+| 2023-5-31 | CityJS Athens 2023 | [Do not thrash the Node.js Event Loop](pages/2023/cityjs-athens.md) |  |  | [🇬🇷](## "Greece") | English |
 | 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
 
 
@@ -294,4 +295,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:55:45.847Z</i>
+<i>Updated on 2026-02-14T10:40:36.876Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-116-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-76-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -7,7 +7,7 @@
 
 
  - [Year of 2025](#2025) - total events 5
- - [Year of 2024](#2024) - total events 3
+ - [Year of 2024](#2024) - total events 4
  - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
@@ -40,7 +40,7 @@
 # 2024
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
 
 
 
@@ -50,6 +50,7 @@
 | 2024-6-24 | Frontend Nation 2024 | [Which Node.js HTTP client in 2024?](pages/2024/frontend-nation-http-client.md) |  | [Recording](https://www.youtube.com/watch?v=fePTmnQHQZ4) |  | English |
 | 2024-5-1 | JSDay 2024 | [The State of Node.js 2024](pages/2024/jsday-2024.md) |  |  | [🇮🇹](## "Italy") | English |
 | 2024-4-17 | Node Congress 2024 | [Deep Dive into Undici](pages/2024/node-congress-deep-dive-undici.md) |  | [Recording](https://www.youtube.com/watch?v=cIyiDDts0lo) | [🇩🇪](## "Germany") | English |
+| 2024-4-5 | CityJS London 2024 | [The Alleged 'End' of Node.js is Much Ado About Nothing](pages/2024/cityjs-london.md) |  |  | [🇬🇧](## "United Kingdom") | English |
 
 
 # 2023
@@ -295,4 +296,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T10:40:36.876Z</i>
+<i>Updated on 2026-02-14T10:41:23.888Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -8,8 +8,8 @@
 
  - [Year of 2025](#2025) - total events 3
  - [Year of 2024](#2024) - total events 3
- - [Year of 2023](#2023) - total events 4
- - [Year of 2022](#2022) - total events 7
+ - [Year of 2023](#2023) - total events 6
+ - [Year of 2022](#2022) - total events 8
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
  - [Year of 2019](#2019) - total events 10
@@ -53,7 +53,7 @@
 # 2023
 
 
-![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
 
 
 
@@ -63,19 +63,22 @@
 | 2023-12-2 | Node.js fwdays'23 | [NODE_ENV=production is a lie](pages/2023/fwdays-nodejs-node-env.md) |  | [Recording](https://www.youtube.com/watch?v=irRsEfCTTtg) |  | English |
 | 2023-10-17 | React + TypeScript fwdays'23 | [Generating types without climbing a tree](pages/2023/react-typescript-fwdays-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3dSNut_iiVY) |  | English |
 | 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
+| 2023-6-2 | JSNation 2023 | [APIs are Evolving. Again](pages/2023/jsnation-apis-evolving.md) |  | [Recording](https://www.youtube.com/watch?v=P3yu0bQtLLI) | [🇳🇱](## "Netherlands") | English |
+| 2023-6-1 | JSNation 2023 | [I Would Never Use an ORM](pages/2023/jsnation-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=bEy2QMKrcWg) | [🇳🇱](## "Netherlands") | English |
 | 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
 
 
 # 2022
 
 
-![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+![Total Events](https://img.shields.io/badge/total-8-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2022-10-1 | NodeConf EU 2022 | [I would never use an ORM](pages/2022/nodeconf-eu-never-use-orm.md) |  | [Recording](https://www.youtube.com/watch?v=atABji4xqiI) | [🇮🇪](## "Ireland") | English |
 | 2022-6-7 | OpenJS World 2022 | [Keynote - Everybody is Responsible for Performance](pages/2022/openjs-world-keynote.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [A Fastify tale of Shapes](pages/2022/openjs-world-fastify.md) |  | [Recording](https://www.youtube.com/watch?v=g-6Ig8k6Nzc&list=PLyspMSh4XhLMSpb4yqi0aPxSioNaP1Wkn) | [🇺🇸](## "United States") | English |
 | 2022-6-6 | OpenJS World 2022 | [Everybody is Responsible for Performance](pages/2022/openjs-world-performance.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
@@ -289,4 +292,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:32:40.646Z</i>
+<i>Updated on 2026-02-14T09:40:59.290Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-113-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-73-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 3
+ - [Year of 2025](#2025) - total events 4
  - [Year of 2024](#2024) - total events 3
  - [Year of 2023](#2023) - total events 6
  - [Year of 2022](#2022) - total events 8
@@ -23,7 +23,7 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
 
 
 
@@ -31,6 +31,7 @@
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
 | 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
 
@@ -292,4 +293,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:40:59.290Z</i>
+<i>Updated on 2026-02-14T09:42:41.643Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-97-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-57-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-110-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-70-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,10 @@
 # Table of Contents
 
 
- - [Year of 2022](#2022) - total events 4
+ - [Year of 2025](#2025) - total events 3
+ - [Year of 2024](#2024) - total events 3
+ - [Year of 2023](#2023) - total events 4
+ - [Year of 2022](#2022) - total events 7
  - [Year of 2021](#2021) - total events 29
  - [Year of 2020](#2020) - total events 23
  - [Year of 2019](#2019) - total events 10
@@ -17,16 +20,65 @@
  - [Year of 2014](#2014) - total events 5
  - [Year of 2013](#2013) - total events 2
 
-# 2022
+# 2025
 
 
-![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-1-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
+| 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
+
+
+# 2024
+
+
+![Total Events](https://img.shields.io/badge/total-3-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-3-red?style=flat-square)    
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2024-6-24 | Frontend Nation 2024 | [Which Node.js HTTP client in 2024?](pages/2024/frontend-nation-http-client.md) |  | [Recording](https://www.youtube.com/watch?v=fePTmnQHQZ4) |  | English |
+| 2024-5-1 | JSDay 2024 | [The State of Node.js 2024](pages/2024/jsday-2024.md) |  |  | [🇮🇹](## "Italy") | English |
+| 2024-4-17 | Node Congress 2024 | [Deep Dive into Undici](pages/2024/node-congress-deep-dive-undici.md) |  | [Recording](https://www.youtube.com/watch?v=cIyiDDts0lo) | [🇩🇪](## "Germany") | English |
+
+
+# 2023
+
+
+![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2023-12-2 | Node.js fwdays'23 | [NODE_ENV=production is a lie](pages/2023/fwdays-nodejs-node-env.md) |  | [Recording](https://www.youtube.com/watch?v=irRsEfCTTtg) |  | English |
+| 2023-10-17 | React + TypeScript fwdays'23 | [Generating types without climbing a tree](pages/2023/react-typescript-fwdays-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3dSNut_iiVY) |  | English |
+| 2023-9-21 | TypeScript Congress 2023 | [Generating types without climbing a tree](pages/2023/typescript-congress-generating-types.md) |  | [Recording](https://www.youtube.com/watch?v=3BROtlRhDYE) |  | English |
+| 2023-4-14 | Node Congress 2023 | [Building a modular monolith with Fastify](pages/2023/node-congress-modular-monolith.md) |  | [Recording](https://www.youtube.com/watch?v=e1jkA-ee_aY) | [🇩🇪](## "Germany") | English |
+
+
+# 2022
+
+
+![Total Events](https://img.shields.io/badge/total-7-blue?style=flat-square) ![Total Meetups](https://img.shields.io/badge/meetups-1-violet?style=flat-square) ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square) ![Total Podcasts](https://img.shields.io/badge/podcasts-2-yellow?style=flat-square)   
+
+
+
+
+| Date | Event | Title | Slides | Recording | Location | Language |
+| ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2022-6-7 | OpenJS World 2022 | [Keynote - Everybody is Responsible for Performance](pages/2022/openjs-world-keynote.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
+| 2022-6-6 | OpenJS World 2022 | [A Fastify tale of Shapes](pages/2022/openjs-world-fastify.md) |  | [Recording](https://www.youtube.com/watch?v=g-6Ig8k6Nzc&list=PLyspMSh4XhLMSpb4yqi0aPxSioNaP1Wkn) | [🇺🇸](## "United States") | English |
+| 2022-6-6 | OpenJS World 2022 | [Everybody is Responsible for Performance](pages/2022/openjs-world-performance.md) |  | [Recording](https://www.youtube.com/watch?v=A99zkgoFd18) | [🇺🇸](## "United States") | English |
 | 2022-2-25 | Design Talk | [Always put the client first](pages/2022/design-talk.md) |  | [Recording](https://shows.acast.com/design-talk/episodes/always-put-the-client-first) |  | English |
 | 2022-2-25 | PodRocket | [Fastify and Pino with Matteo Collina](pages/2022/podrocket.md) |  | [Recording](https://podrocket.logrocket.com/fastify) |  | English |
 | 2022-2-1 | GraphQL Berlin Meetup | [GraphQL Caching Demystified](pages/2022/graphql-berlin-meetup.md) |  | [Recording](https://youtu.be/srkTmlFNOyw) |  | English |
@@ -237,4 +289,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2022-05-10T09:36:52.301Z</i>
+<i>Updated on 2026-02-14T09:32:40.646Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-114-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-74-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-115-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-75-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 4
+ - [Year of 2025](#2025) - total events 5
  - [Year of 2024](#2024) - total events 3
  - [Year of 2023](#2023) - total events 6
  - [Year of 2022](#2022) - total events 8
@@ -23,13 +23,14 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-4-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-4-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-5-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square)    
 
 
 
 
 | Date | Event | Title | Slides | Recording | Location | Language |
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
+| 2025-11-1 | JSConf 2025 | [Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work](pages/2025/jsconf-us.md) |  | [Recording](https://www.youtube.com/watch?v=2VkUF8jzouQ) | [🇺🇸](## "United States") | English |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
 | 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
@@ -293,4 +294,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T09:42:41.643Z</i>
+<i>Updated on 2026-02-14T09:55:45.847Z</i>

--- a/gigsboat-eleventy-starter/index.md
+++ b/gigsboat-eleventy-starter/index.md
@@ -1,4 +1,4 @@
-<div align='center'><p><img src="https://img.shields.io/badge/total-117-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-77-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
+<div align='center'><p><img src="https://img.shields.io/badge/total-118-blue?style=flat-square" alt="Total Events"> <img src="https://img.shields.io/badge/meetups-2-violet?style=flat-square" alt="Total Meetups"> <img src="https://img.shields.io/badge/conferences-78-red?style=flat-square" alt="Total Conferences"> <img src="https://img.shields.io/badge/podcasts-27-yellow?style=flat-square" alt="Total Podcasts"> <img src="https://img.shields.io/badge/webinars-6-lightgrey?style=flat-square" alt="Total Webinars">  <img src="https://img.shields.io/badge/workshops-5-orange?style=flat-square" alt="Total Workshops"></p>
 </div>
   <p align='center'><h1 align='center'>Matteo Collina  - Public Speaking</h1>
 <p align='center'><a href='https://nodejs.org' target='_blank'>Node.js</a> TSC member, PhD, Chief Software Architect <a href='https://nearform.com/' target='_blank'>NearForm</a>, Lead maintainer <a href='https://fastify.io target='_blank'>Fastify</a></p></p><p align='center'><a href='matteo_collina'><img alt='Twitter Follow' src='https://img.shields.io/twitter/follow/matteocollina?style=social'></a> <a href='https://www.linkedin.com/in/matteocollina'><img alt='LinkedIn Add Me' src='https://img.shields.io/badge/-Add&nbsp;Me&nbsp;on&nbsp;LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white'></a></p><p align='center'><img src='https://github.com/mcollina/public-speaking/blob/main/static/matteo-collina-header-image.jpg?raw=true' alt='Matteo Collina public speaking profile' /></p>
@@ -6,7 +6,7 @@
 # Table of Contents
 
 
- - [Year of 2025](#2025) - total events 5
+ - [Year of 2025](#2025) - total events 6
  - [Year of 2024](#2024) - total events 4
  - [Year of 2023](#2023) - total events 7
  - [Year of 2022](#2022) - total events 8
@@ -23,7 +23,7 @@
 # 2025
 
 
-![Total Events](https://img.shields.io/badge/total-5-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-5-red?style=flat-square)    
+![Total Events](https://img.shields.io/badge/total-6-blue?style=flat-square)  ![Total Conferences](https://img.shields.io/badge/conferences-6-red?style=flat-square)    
 
 
 
@@ -32,6 +32,7 @@
 | ---- | ----- | ----- | ------ | --------- | -------- | -------- |
 | 2025-11-1 | JSConf 2025 | [Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work](pages/2025/jsconf-us.md) |  | [Recording](https://www.youtube.com/watch?v=2VkUF8jzouQ) | [🇺🇸](## "United States") | English |
 | 2025-10-14 | JSDay 2025 | [The State of Node.js 2025](pages/2025/jsday-state-of-nodejs-2025.md) |  | [Recording](https://www.youtube.com/watch?v=h3qKJabs7d4) | [🇮🇹](## "Italy") | English |
+| 2025-9-3 | Code Europe 2025 | [Node.js: More Threads Than You Think](pages/2025/code-europe.md) |  | [Recording](https://www.youtube.com/watch?v=r5PIqYyRiAg) | [🇵🇱](## "Poland") | English |
 | 2025-6-12 | JSNation 2025 | [The State of Node.js 2025](pages/2025/jsnation-amsterdam.md) |  | [Recording](https://www.youtube.com/watch?v=IgSwJaheiGk) | [🇳🇱](## "Netherlands") | English |
 | 2025-4-3 | dotJS 2025 | [Node.js will use all the memory available, and that's OK!](pages/2025/dotjs-nodejs-memory.md) |  | [Recording](https://www.youtube.com/watch?v=_OnTUIYxGRs) | [🇫🇷](## "France") | English |
 | 2025-3-15 | Conference 2025 | [Why Node.js Needs an Application Server](pages/2025/why-nodejs-needs-application-server.md) |  |  |  | English |
@@ -296,4 +297,4 @@
 
 _A few talks have been omitted or have gone into oblivion._
 
-<i>Updated on 2026-02-14T10:41:23.888Z</i>
+<i>Updated on 2026-02-14T10:42:30.039Z</i>

--- a/pages/2022/nodeconf-eu-never-use-orm.md
+++ b/pages/2022/nodeconf-eu-never-use-orm.md
@@ -1,0 +1,19 @@
+---
+date: 2022-10-01
+tags: post
+name: NodeConf EU 2022
+url: https://nodeconf.eu/
+type: conference
+title: I would never use an ORM
+slides_url:
+recording_url: https://www.youtube.com/watch?v=atABji4xqiI
+city: Kilkenny
+country: Ireland
+country_code: IE
+language: English
+recognitions:
+image_header:
+images:
+---
+
+What's an ORM? An Object-Relational Mapping tool (ORM) is a library to map a SQL table to a Class. In most cases, ORMs force the users to structure their code into Model objects that include both data access and business logic. This talk shares the journey from using ORMs to avoiding them, and finally to Platformatic DB as a better solution.

--- a/pages/2022/openjs-world-keynote.md
+++ b/pages/2022/openjs-world-keynote.md
@@ -1,0 +1,19 @@
+---
+date: 2022-06-07
+tags: post
+name: OpenJS World 2022
+url: https://events.linuxfoundation.org/openjs-world/
+type: conference
+title: Keynote - Everybody is Responsible for Performance
+slides_url:
+recording_url: https://www.youtube.com/watch?v=A99zkgoFd18
+city: Austin, TX
+country: United States
+country_code: US
+language: English
+recognitions:
+image_header:
+images:
+---
+
+A keynote about performance responsibility in Node.js applications and how everyone on the team should care about performance.

--- a/pages/2023/cityjs-athens.md
+++ b/pages/2023/cityjs-athens.md
@@ -1,0 +1,19 @@
+---
+date: 2023-05-31
+tags: post
+name: CityJS Athens 2023
+url: https://athens.cityjsconf.org/
+type: conference
+title: Do not thrash the Node.js Event Loop
+slides_url:
+recording_url:
+city: Athens
+country: Greece
+country_code: GR
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Deploying Node.js at scale is an art mastered by few. The most common problem is an exhaustion of resources that allows the application to denial of service itself. The result is Node.js systems that are massively overprovisioned, wasting enormous amounts of computing and memory - keeping most of them idle. In this talk, we will do some math, discover hard truths, and implement a fix.

--- a/pages/2023/fwdays-nodejs-node-env.md
+++ b/pages/2023/fwdays-nodejs-node-env.md
@@ -1,0 +1,19 @@
+---
+date: 2023-12-02
+tags: post
+name: Node.js fwdays'23
+url: https://fwdays.com/en/event/node-js-fwdays-2023
+type: conference
+title: NODE_ENV=production is a lie
+slides_url:
+recording_url: https://www.youtube.com/watch?v=irRsEfCTTtg
+city: Online
+country:
+country_code:
+language: English
+recognitions:
+image_header:
+images:
+---
+
+In this talk, I explain why NODE_ENV=production is a lie and what you should do instead to properly configure your Node.js applications for production environments.

--- a/pages/2023/jsnation-apis-evolving.md
+++ b/pages/2023/jsnation-apis-evolving.md
@@ -1,0 +1,19 @@
+---
+date: 2023-06-02
+tags: post
+name: JSNation 2023
+url: https://jsnation.com/
+type: conference
+title: APIs are Evolving. Again
+slides_url:
+recording_url: https://www.youtube.com/watch?v=P3yu0bQtLLI
+city: Amsterdam
+country: Netherlands
+country_code: NL
+language: English
+recognitions:
+image_header:
+images:
+---
+
+As developers we stand on the shoulders of giants, and it can be helpful to take a look at the past to gain a better perspective. In this talk we briefly explore the past decade of backend development and architectural patterns. We've often ditched technologies in an attempt to make the developer experience frictionless. However we sometimes forget what we can learn from "the good old days". A shift in how we see things can help us keep moving forwards.

--- a/pages/2023/jsnation-never-use-orm.md
+++ b/pages/2023/jsnation-never-use-orm.md
@@ -1,0 +1,19 @@
+---
+date: 2023-06-01
+tags: post
+name: JSNation 2023
+url: https://jsnation.com/
+type: conference
+title: I Would Never Use an ORM
+slides_url:
+recording_url: https://www.youtube.com/watch?v=bEy2QMKrcWg
+city: Amsterdam
+country: Netherlands
+country_code: NL
+language: English
+recognitions:
+image_header:
+images:
+---
+
+ORMs are often a hurdle to overcome for the most complex part of a project. As the next stop of my journey, I recommended people use the native languages of their databases, e.g., SQL. This works great for the most part, but it creates quite a struggle: there is a lot of boilerplate code to write that can be pretty tedious. Today I'm presenting you Platformatic DB.

--- a/pages/2023/node-congress-modular-monolith.md
+++ b/pages/2023/node-congress-modular-monolith.md
@@ -1,0 +1,19 @@
+---
+date: 2023-04-14
+tags: post
+name: Node Congress 2023
+url: https://nodecongress.com/2023/
+type: conference
+title: Building a modular monolith with Fastify
+slides_url:
+recording_url: https://www.youtube.com/watch?v=e1jkA-ee_aY
+city: Berlin
+country: Germany
+country_code: DE
+language: English
+recognitions:
+image_header:
+images:
+---
+
+A talk about building modular monoliths with Fastify, showing how to structure larger applications while maintaining the benefits of a monolithic architecture.

--- a/pages/2023/react-typescript-fwdays-generating-types.md
+++ b/pages/2023/react-typescript-fwdays-generating-types.md
@@ -1,0 +1,19 @@
+---
+date: 2023-10-17
+tags: post
+name: React + TypeScript fwdays'23
+url: https://fwdays.com/en/event/react-ts-fwdays-2023
+type: conference
+title: Generating types without climbing a tree
+slides_url:
+recording_url: https://www.youtube.com/watch?v=3dSNut_iiVY
+city: Online
+country:
+country_code:
+language: English
+recognitions:
+image_header:
+images:
+---
+
+How do you generate types dynamically? How do you write a script that creates some TypeScript code? This talk explores approaches to generating TypeScript types without using complex AST manipulations, sharing a practical and easy-to-implement solution developed for an OpenAPI client under a tight deadline.

--- a/pages/2023/typescript-congress-generating-types.md
+++ b/pages/2023/typescript-congress-generating-types.md
@@ -1,0 +1,19 @@
+---
+date: 2023-09-21
+tags: post
+name: TypeScript Congress 2023
+url: https://typescriptcongress.com/
+type: conference
+title: Generating types without climbing a tree
+slides_url:
+recording_url: https://www.youtube.com/watch?v=3BROtlRhDYE
+city: Online
+country:
+country_code:
+language: English
+recognitions:
+image_header:
+images:
+---
+
+How do you generate types dynamically? How do you write a script that creates some TypeScript code? This talk explores approaches to generating TypeScript types without using complex AST manipulations, sharing a practical and easy-to-implement solution developed for an OpenAPI client under a tight deadline.

--- a/pages/2024/cityjs-london.md
+++ b/pages/2024/cityjs-london.md
@@ -1,0 +1,19 @@
+---
+date: 2024-04-05
+tags: post
+name: CityJS London 2024
+url: https://london.cityjsconf.org/
+type: conference
+title: The Alleged 'End' of Node.js is Much Ado About Nothing
+slides_url:
+recording_url:
+city: London
+country: United Kingdom
+country_code: GB
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Despite the exaggerated claims about its decline, Node.js is thriving. Its continued evolution pushes the boundaries of what the modern web can do. We'll start by debunking myths about Node.js, showcasing its recent enhancements and robust performance in the tech landscape. The focus then shifts to Node.js's current role in server-side programming and cloud-native applications, emphasizing the vibrant community contributions that drive its progress. We'll also explore how integrating modern JavaScript features and the influence of emerging technologies are shaping Node.js's future, not signaling its end. Concluding, the talk projects a bright future for Node.js, identifying growth areas and dispelling any misconceptions about its relevance in the evolving world of technology.

--- a/pages/2024/frontend-nation-http-client.md
+++ b/pages/2024/frontend-nation-http-client.md
@@ -1,0 +1,19 @@
+---
+date: 2024-06-24
+tags: post
+name: Frontend Nation 2024
+url: https://frontendnation.com/
+type: conference
+title: Which Node.js HTTP client in 2024?
+slides_url:
+recording_url: https://www.youtube.com/watch?v=fePTmnQHQZ4
+city: Online
+country:
+country_code:
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Choosing the right HTTP client is a critical decision when building dynamic web applications with Node.js. In this comprehensive talk, I explore the available HTTP client options in Node.js for 2024 and help you make an informed decision.

--- a/pages/2024/jsday-2024.md
+++ b/pages/2024/jsday-2024.md
@@ -1,0 +1,19 @@
+---
+date: 2024-05-01
+tags: post
+name: JSDay 2024
+url: https://2024.jsday.it/
+type: conference
+title: The State of Node.js 2024
+slides_url:
+recording_url:
+city: Verona
+country: Italy
+country_code: IT
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Node.js continues to thrive despite exaggerated claims about its decline. Its continued evolution pushes the boundaries of what the modern web can do. We cover Node.js's role in server-side programming and cloud-native applications, community contributions, integration of modern JavaScript features, and influence of emerging technologies.

--- a/pages/2024/node-congress-deep-dive-undici.md
+++ b/pages/2024/node-congress-deep-dive-undici.md
@@ -1,0 +1,19 @@
+---
+date: 2024-04-17
+tags: post
+name: Node Congress 2024
+url: https://nodecongress.com/
+type: conference
+title: Deep Dive into Undici
+slides_url:
+recording_url: https://www.youtube.com/watch?v=cIyiDDts0lo
+city: Berlin
+country: Germany
+country_code: DE
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Undici, the next-generation HTTP client built by the Node.js Core team, powers Node.js core fetch(). Let’s dig into how its internals work, discovering how to work with Dispatchers, Agents, and Pools. Last but not least, we’ll even do some magic.

--- a/pages/2025/code-europe.md
+++ b/pages/2025/code-europe.md
@@ -1,0 +1,19 @@
+---
+date: 2025-09-03
+tags: post
+name: Code Europe 2025
+url: https://www.codeeurope.pl/
+type: conference
+title: "Node.js: More Threads Than You Think"
+slides_url:
+recording_url: https://www.youtube.com/watch?v=r5PIqYyRiAg
+city: Krakow
+country: Poland
+country_code: PL
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Is Node.js really single-threaded? The answer has changed. Node.js was announced in 2009 as a single-threaded JavaScript runtime. In 2018, it became multi-threaded, and no one noticed. Learn how to leverage multi-threading to build faster, more scalable applications with worker_threads.

--- a/pages/2025/dotjs-nodejs-memory.md
+++ b/pages/2025/dotjs-nodejs-memory.md
@@ -1,0 +1,19 @@
+---
+date: 2025-04-03
+tags: post
+name: dotJS 2025
+url: https://www.dotjs.io/
+type: conference
+title: Node.js will use all the memory available, and that's OK!
+slides_url:
+recording_url: https://www.youtube.com/watch?v=_OnTUIYxGRs
+city: Paris
+country: France
+country_code: FR
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Talk recorded at the 10th edition of the dotJS conference at the Folies Bergère theater in Paris. Node.js will use all the memory available, and that's completely fine and expected behavior.

--- a/pages/2025/jsconf-us.md
+++ b/pages/2025/jsconf-us.md
@@ -1,0 +1,19 @@
+---
+date: 2025-11-01
+tags: post
+name: JSConf 2025
+url: https://2025.jsconf.com/
+type: conference
+title: "Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work"
+slides_url:
+recording_url: https://www.youtube.com/watch?v=2VkUF8jzouQ
+city:
+country: United States
+country_code: US
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Remember when profiling Node.js meant wrestling with perf, sed scripts, and mysterious V8 internals? Traditional flame graph generation has been like performing surgery with a sledgehammer. In this talk, Matteo opens with humor before diving into a core problem many developers face: traditional Node.js profiling tools are slow, confusing, and challenging to use in real environments like Docker or production. He presents a next-generation approach to Node.js performance profiling that actually works.

--- a/pages/2025/jsday-state-of-nodejs-2025.md
+++ b/pages/2025/jsday-state-of-nodejs-2025.md
@@ -1,0 +1,19 @@
+---
+date: 2025-10-14
+tags: post
+name: JSDay 2025
+url: https://2025.jsday.it/
+type: conference
+title: The State of Node.js 2025
+slides_url:
+recording_url: https://www.youtube.com/watch?v=h3qKJabs7d4
+city: Verona
+country: Italy
+country_code: IT
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Despite exaggerated claims about its decline, Node.js is thriving. Its continued evolution pushes the boundaries of what the modern web can do. We'll start by debunking common myths about Node.js, then highlight recent enhancements and demonstrate its robust performance in today's tech landscape.

--- a/pages/2025/jsnation-amsterdam.md
+++ b/pages/2025/jsnation-amsterdam.md
@@ -1,0 +1,19 @@
+---
+date: 2025-06-12
+tags: post
+name: JSNation 2025
+url: https://jsnation.com/2025/
+type: conference
+title: The State of Node.js 2025
+slides_url:
+recording_url: https://www.youtube.com/watch?v=IgSwJaheiGk
+city: Amsterdam
+country: Netherlands
+country_code: NL
+language: English
+recognitions:
+image_header:
+images:
+---
+
+Node.js continues to thrive despite claims of its decline. We debunk myths, highlight recent enhancements, and demonstrate its robust performance in today's tech landscape. The talk covers Node.js's role in server-side programming and cloud-native applications, community contributions, integration of modern JavaScript features, and influence of emerging technologies.

--- a/pages/2025/why-nodejs-needs-application-server.md
+++ b/pages/2025/why-nodejs-needs-application-server.md
@@ -1,0 +1,19 @@
+---
+date: 2025-03-15
+tags: post
+name: Conference 2025
+url:
+type: conference
+title: Why Node.js Needs an Application Server
+slides_url:
+recording_url:
+city:
+country:
+country_code:
+language: English
+recognitions:
+image_header:
+images:
+---
+
+You've been deploying Node.js wrong. For years, the community has treated Node.js as a simple runtime—start a process, put it behind a reverse proxy, scale horizontally. But this approach ignores fundamental architectural problems that become painfully obvious in production. I make the case for why Node.js needs a proper application server—and why we built Watt to solve these problems. Real benchmark data shows 93% faster median latency and 99.8% reliability under sustained load.


### PR DESCRIPTION
This PR adds missing talks from 2022-2025 to the public speaking portfolio.

## Added Talks

### 2022
- OpenJS World Keynote: Everybody is Responsible for Performance
- NodeConf EU: I would never use an ORM

### 2023
- Node Congress: Building a modular monolith with Fastify
- TypeScript Congress: Generating types without climbing a tree
- React+TS fwdays: Generating types without climbing a tree
- fwdays Node.js: NODE_ENV=production is a lie
- CityJS Athens: Do not thrash the Node.js Event Loop
- JSNation Amsterdam: I Would Never Use an ORM
- JSNation Amsterdam: APIs are Evolving. Again (with Luca Maraschi)

### 2024
- Node Congress: Deep Dive into Undici
- CityJS London: The Alleged 'End' of Node.js is Much Ado About Nothing
- Frontend Nation: Which Node.js HTTP client in 2024?
- JSDay: The State of Node.js 2024

### 2025
- JSNation Amsterdam: The State of Node.js 2025
- JSConf US: Next-Gen Flame Graphs: Making Node.js Performance Profiling Actually Work
- Code Europe: Node.js: More Threads Than You Think
- dotJS: Node.js will use all the memory available
- JSDay: The State of Node.js 2025
- Why Node.js Needs an Application Server

Total: 19 talks added. All talks include proper metadata including dates, locations, recording URLs, and abstracts.